### PR TITLE
Fix for issue #10 to allow migrations to work with MySQL v8

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -52,6 +52,14 @@ return [
             'prefix' => '',
             'strict' => true,
             'engine' => null,
+            'modes'  => [
+                'ONLY_FULL_GROUP_BY',
+                'STRICT_TRANS_TABLES',
+                'NO_ZERO_IN_DATE',
+                'NO_ZERO_DATE',
+                'ERROR_FOR_DIVISION_BY_ZERO',
+                'NO_ENGINE_SUBSTITUTION',
+            ],
         ],
 
         'pgsql' => [


### PR DESCRIPTION
This allows MySQL to work with version 8, has many features such as ZERO_DATE, NO_AUTO_CREATE_USER, etc are deprecated in MySQL v8